### PR TITLE
fix: Include index.d.ts in dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,9 @@
   },
   "dependencies": {
     "lodash": "^4.17.11"
-  }
+  },
+  "files": [
+    "dist",
+    "index.d.ts"
+  ]
 }


### PR DESCRIPTION
When creating  the dist/ folder include the index.d.ts. Else
when using this package typescript complains about missing
types.